### PR TITLE
add metrics used in promethues

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ with `gluster volume info` this is obsolete
 | volStatus.volumes.volume[].node[].sizeTotal | Gauge | hostname, path, volume | implemented |
 
 
+### Metrics in prometheus
+| Name          		| Descritpion     |
+| ------------  		| -------- |
+| up       				| Was the last query of Gluster successful.    |
+| volumes_count         | How many volumes were up at the last query.    |
+| volume_status        	| Status code of requested volume.    |
+| node_size_free_bytes	| Free bytes reported for each node on each instance. Labels are to distinguish origins    |
+| node_size_total_bytes | Total bytes reported for each node on each instance. Labels are to distinguish origins    |
+| brick_count 			| Number of bricks at last query.    |
+| brick_duration 		| Time running volume brick.    |
+| brick_data_read 		| Total amount of data read by brick.    |
+| brick_data_written 	| Total amount of data written by brick.    |
+| brick_fop_hits 		| Total amount of file operation hits.    |
+| brick_fop_latency_avg | Average fileoperations latency over total uptime    |
+| brick_fop_latency_min | Minimum fileoperations latency over total uptime    |
+| brick_fop_latency_max | Maximum fileoperations latency over total uptime    |
+| peers_connected 		| Is peer connected to gluster cluster.    |
+| heal_info_files_count | File count of files out of sync, when calling 'gluster v heal VOLNAME info    |
+| volume_writeable 		| Writes and deletes file in Volume and checks if it is writeable    |
+| mount_successful 		| Checks if mountpoint exists, returns a bool value 0 or 1    |
+
 ## Troubleshooting
 If the following message appears while trying to get some information out of your gluster. Increase scrape interval in `prometheus.yml` to at least 30s.
 


### PR DESCRIPTION
I added the metrics that are actually displaying in prometheus. Just extract the description from `main.go`.

I did this because I felt confused when I skim through the README: say, I want to get `volProfile.cumulativeStatus.totalWrite`, but there is no metrics called `volProfile...` in prometheus...