### PR TITLE
gluster_peers_connected vs gluster_peers_total 

### DIFF
--- a/main.go
+++ b/main.go
@@ -255,7 +255,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 	countTotal := 0
 	countConnected := 0
-    for p := range peerStatus.Peer {
+    for _, p := range peerStatus.Peer {
 		countTotal++
 		if p.Connected == 1 {
 		    countConnected++


### PR DESCRIPTION
Hey, here is a small PR that implements the "connected" status for peers in a Gluster cluster. 

`
#HELP gluster_peers_connected Cluster peers in Connected status.

#TYPE gluster_peers_connected gauge

gluster_peers_connected 2

#HELP gluster_peers_total Total number of peers in cluster.

#TYPE gluster_peers_total gauge

gluster_peers_total 2 
`

I am not a golang coder (these are actually the first lines I´ve ever written in Go), so I am sure there is plenty of room for improvement, however, this fix seems to work for me.

Thank you for starting this project btw! 

