### PR TITLE
Add inode metrics

### DIFF
--- a/gluster_client.go
+++ b/gluster_client.go
@@ -102,9 +102,7 @@ func ExecPeerStatus() (structs.PeerStatus, error) {
 // ExecVolumeProfileGvInfoCumulative executes "gluster volume {volume] profile info cumulative" at the local machine and
 // returns VolumeInfoXML struct and error
 func ExecVolumeProfileGvInfoCumulative(volumeName string) (structs.VolProfile, error) {
-	args := []string{"volume", "profile"}
-	args = append(args, volumeName)
-	args = append(args, "info", "cumulative")
+	args := []string{"volume", "profile", volumeName, "info", "cumulative"}
 	bytesBuffer, cmdErr := execGlusterCommand(args...)
 	if cmdErr != nil {
 		return structs.VolProfile{}, cmdErr

--- a/main.go
+++ b/main.go
@@ -61,8 +61,20 @@ var (
 	)
 
 	nodeSizeTotalBytes = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "", "node_size_total_bytes"),
+		prometheus.BuildFQName(namespace, "", "node_size_bytes_total"),
 		"Total bytes reported for each node on each instance. Labels are to distinguish origins",
+		[]string{"hostname", "path", "volume"}, nil,
+	)
+
+	nodeInodesTotal = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "node_inodes_total"),
+		"Total inodes bytes reported for each node on each instance. Labels are to distinguish origins",
+		[]string{"hostname", "path", "volume"}, nil,
+	)
+
+	nodeInodesFree = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "node_inodes_free"),
+		"Free inodes reported for each node on each instance. Labels are to distinguish origins",
 		[]string{"hostname", "path", "volume"}, nil,
 	)
 
@@ -311,7 +323,14 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			)
 
 			ch <- prometheus.MustNewConstMetric(
-				nodeSizeFreeBytes, prometheus.CounterValue, float64(node.SizeFree), node.Hostname, node.Path, vol.VolName,
+				nodeSizeFreeBytes, prometheus.GaugeValue, float64(node.SizeFree), node.Hostname, node.Path, vol.VolName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				nodeInodesTotal, prometheus.CounterValue, float64(node.InodesTotal), node.Hostname, node.Path, vol.VolName,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				nodeInodesFree, prometheus.GaugeValue, float64(node.InodesFree), node.Hostname, node.Path, vol.VolName,
 			)
 		}
 	}

--- a/structs/xmlStructs.go
+++ b/structs/xmlStructs.go
@@ -261,6 +261,10 @@ type VolumeStatusXML struct {
 					BlockSize  int    `xml:"blockSize"`
 					MntOptions string `xml:"mntOptions"`
 					FsName     string `xml:"fsName"`
+					// As of Gluster3.12 this shows filesystem type. Bug?
+					//InodeSize  uint64 `xml:"inodeSize"`
+					InodesTotal uint64 `xml:"inodesTotal"`
+					InodesFree  uint64 `xml:"inodesFree"`
 				} `xml:"node"`
 			} `xml:"volume"`
 		} `xml:"volumes"`


### PR DESCRIPTION
Hi @ofesseler, 

I added the `inodesTotal` and `inodesFree` metrics here. With `inodeSize` it seems to be a bug not reporting the real inode size with the `--xml` flag, and that is why I leave it commented for future investigations. This fixes #27. 

About the Total and Free metrics, it turns out, that a Total metric should be a counter type and Free a gauge type for Prometheus. You can check this here [gauge](https://prometheus.io/docs/concepts/metric_types/#gauge) and [counter]( https://prometheus.io/docs/concepts/metric_types/#counter). This fixes #25 partially.

See,

```
$ curl -s http://localhost:9189/metrics | promtool check metrics
gluster_brick_data_read counter metrics should have "_total" suffix
gluster_brick_data_written counter metrics should have "_total" suffix
gluster_brick_duration counter metrics should have "_total" suffix
gluster_brick_count non-histogram and non-summary metrics should not have "_count" suffix
gluster_brick_fop_hits counter metrics should have "_total" suffix
gluster_brick_fop_latency_avg counter metrics should have "_total" suffix
gluster_brick_fop_latency_max counter metrics should have "_total" suffix
gluster_brick_fop_latency_min counter metrics should have "_total" suffix
gluster_volumes_count non-histogram and non-summary metrics should not have "_count" suffix
``` 