### PR TITLE
Added parsing for hostname

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"net/http"
-
+	"regexp"
 	"fmt"
 	"os"
 	"strings"
@@ -531,7 +531,12 @@ func main() {
 	log.Infoln("Starting gluster_exporter", version.Info())
 	log.Infoln("Build context", version.BuildContext())
 
-	hostname, err := os.Hostname()
+	hostnameH, err := os.Hostname()
+        var validval =  regexp.MustCompile("[a-zA-Z0-9]*")
+        hostnameE := validval.FindStringSubmatch(hostnameH)
+        hostname := hostnameE[0]
+	
+//	hostname, err := os.Hostname()
 	if err != nil {
 		log.Fatalf("While trying to get Hostname error happened: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -532,7 +532,7 @@ func main() {
 	log.Infoln("Build context", version.BuildContext())
 
 	hostnameH, err := os.Hostname()
-        var validval =  regexp.MustCompile("^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$")
+        var validval =  regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`)
         hostnameE := validval.FindStringSubmatch(hostnameH)
         hostname := hostnameE[1]
 	

--- a/main.go
+++ b/main.go
@@ -532,9 +532,9 @@ func main() {
 	log.Infoln("Build context", version.BuildContext())
 
 	hostnameH, err := os.Hostname()
-        var validval =  regexp.MustCompile("[a-zA-Z0-9]*")
+        var validval =  regexp.MustCompile("^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$")
         hostnameE := validval.FindStringSubmatch(hostnameH)
-        hostname := hostnameE[0]
+        hostname := hostnameE[1]
 	
 //	hostname, err := os.Hostname()
 	if err != nil {


### PR DESCRIPTION
main.go has the following condition before collecting cumulative data in line 279:
if strings.HasPrefix(brick.BrickName, e.hostname)

In our case, VM has hostname as FQDN 'somehost.somedomain.tld'. However, gluster volumes have prefix somehost instead of FQDN.
gluster volume info
Bricks:
Brick1: somehost:/var/data/brick1/gv1
Brick2: somehost:/var/data/brick1/gv1
#
This is why condition is not met and profiling metrics are not scrapped.
Solution is to add regex after retrieving hostname and parse only first part of the hostname. Following was added
hostnameH, err := os.Hostname()
var validval = regexp.MustCompile("[a-zA-Z0-9]*")
hostnameE := validval.FindStringSubmatch(hostnameH)
hostname := hostnameE[0]

Such case should be also considered.