### PR TITLE
fix 500 errors and updated to 7.x gluster release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stretch
-MAINTAINER Oliver Fesseler <oliver@fesseler.info>
+LABEL maintainer="mochoa@exa.unicen.edu.ar"
 
 EXPOSE 9189
 EXPOSE 24007
@@ -7,11 +7,11 @@ EXPOSE 24009-24108
 
 RUN apt-get update && apt-get install -y apt-utils apt-transport-https ca-certificates gnupg2
 # Gluster debian Repo
-ADD http://download.gluster.org/pub/gluster/glusterfs/3.12/rsa.pub /tmp
+ADD http://download.gluster.org/pub/gluster/glusterfs/7/rsa.pub /tmp
 RUN apt-key add /tmp/rsa.pub && rm -f /tmp/rsa.pub
 
 # Add gluster debian repo and update apt
-RUN echo "deb https://download.gluster.org/pub/gluster/glusterfs/3.12/LATEST/Debian/stretch/amd64/apt stretch main" > /etc/apt/sources.list.d/gluster.list
+RUN echo "deb https://download.gluster.org/pub/gluster/glusterfs/7/LATEST/Debian/stretch/amd64/apt stretch main" > /etc/apt/sources.list.d/gluster.list
 RUN apt-get update
 
 # Install Gluster server

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,6 +45,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:96bb45b6d2b7cbe94e4bdcfe562bcf484ed0ac92f368b90145e8874d5f86f09e"
+  name = "github.com/ofesseler/gluster_exporter"
+  packages = ["structs"]
+  pruneopts = "UT"
+  revision = "9beb3a0cb0997961b1bebe5536ae3eb3c334949d"
+  version = "v0.2.7"
+
+[[projects]]
   digest = "1:d14a5f4bfecf017cb780bdde1b6483e5deb87e12c332544d2c430eda58734bcb"
   name = "github.com/prometheus/client_golang"
   packages = [
@@ -131,6 +139,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/ofesseler/gluster_exporter/structs",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/common/log",

--- a/gluster-init.sh
+++ b/gluster-init.sh
@@ -6,7 +6,7 @@ VOLNAME="data"
 # Start gluster manually (systemd is not running)
 /usr/sbin/glusterd -p /var/run/glusterd.pid --log-level INFO &
 # Wait to start configuring gluster
-sleep 30
+sleep 10
 # Create a volume
 gluster volume create "$VOLNAME" "$(hostname)":/"$VOLNAME" force
 # Start Gluster volume

--- a/main.go
+++ b/main.go
@@ -325,13 +325,6 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(
 				nodeSizeFreeBytes, prometheus.GaugeValue, float64(node.SizeFree), node.Hostname, node.Path, vol.VolName,
 			)
-			ch <- prometheus.MustNewConstMetric(
-				nodeInodesTotal, prometheus.CounterValue, float64(node.InodesTotal), node.Hostname, node.Path, vol.VolName,
-			)
-
-			ch <- prometheus.MustNewConstMetric(
-				nodeInodesFree, prometheus.GaugeValue, float64(node.InodesFree), node.Hostname, node.Path, vol.VolName,
-			)
 		}
 	}
 	vols := e.volumes
@@ -369,6 +362,10 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			}
 		} else {
 			for _, mount := range mounts {
+				if strings.HasPrefix(mount.mountPoint, "/var/lib/docker/plugins/") {
+					continue
+				}
+
 				ch <- prometheus.MustNewConstMetric(
 					mountSuccessful, prometheus.GaugeValue, float64(1), mount.volume, mount.mountPoint,
 				)

--- a/structs/xmlStructs.go
+++ b/structs/xmlStructs.go
@@ -257,42 +257,59 @@ func VolumeProfileGvInfoCumulativeXMLUnmarshall(cmdOutBuff io.Reader) (VolumePro
 	return vol, err
 }
 
-// VolumeStatusXML XML type of "gluster volume status"
+// VolumeStatusXML XML type of "gluster volume status detail"
 type VolumeStatusXML struct {
-	XMLName   xml.Name `xml:"cliOutput"`
-	OpRet     int      `xml:"opRet"`
-	OpErrno   int      `xml:"opErrno"`
-	OpErrstr  string   `xml:"opErrstr"`
-	VolStatus struct {
-		Volumes struct {
-			Volume []struct {
-				VolName   string `xml:"volName"`
-				NodeCount int    `xml:"nodeCount"`
-				Node      []struct {
-					Hostname string `xml:"hostname"`
-					Path     string `xml:"path"`
-					PeerID   string `xml:"peerid"`
-					Status   int    `xml:"status"`
-					Port     int    `xml:"port"`
-					Ports    struct {
-						TCP  int    `xml:"tcp"`
-						RDMA string `xml:"rdma"`
-					} `xml:"ports"`
-					Pid        int    `xml:"pid"`
-					SizeTotal  uint64 `xml:"sizeTotal"`
-					SizeFree   uint64 `xml:"sizeFree"`
-					Device     string `xml:"device"`
-					BlockSize  int    `xml:"blockSize"`
-					MntOptions string `xml:"mntOptions"`
-					FsName     string `xml:"fsName"`
-					// As of Gluster3.12 this shows filesystem type. Bug?
-					//InodeSize  uint64 `xml:"inodeSize"`
-					InodesTotal uint64 `xml:"inodesTotal"`
-					InodesFree  uint64 `xml:"inodesFree"`
-				} `xml:"node"`
-			} `xml:"volume"`
-		} `xml:"volumes"`
-	} `xml:"volStatus"`
+	XMLName   xml.Name  `xml:"cliOutput"`
+	OpRet     int       `xml:"opRet"`
+	OpErrno   int       `xml:"opErrno"`
+	OpErrstr  string    `xml:"opErrstr"`
+	VolStatus VolStatus `xml:"volStatus"`
+}
+
+// VolStatus XML type of "gluster volume status detail"
+type VolStatus struct {
+	XMLName xml.Name   `xml:"volStatus"`
+	Volumes VolumesXML `xml:"volumes"`
+}
+
+// VolumesXML type of "gluster volume status detail"
+type VolumesXML struct {
+	XMLName xml.Name    `xml:"volumes"`
+	Volume  []VolumeXML `xml:"volume"`
+}
+
+// VolumeXML type of "gluster volume status detail"
+type VolumeXML struct {
+	VolName   string `xml:"volName"`
+	NodeCount int    `xml:"nodeCount"`
+	Node      []Node `xml:"node"`
+}
+
+// Node XML type of "gluster volume status detail"
+type Node struct {
+	Hostname   string `xml:"hostname"`
+	Path       string `xml:"path"`
+	PeerID     string `xml:"peerid"`
+	Status     int    `xml:"status"`
+	Port       int    `xml:"port"`
+	Ports      Ports  `xml:"ports"`
+	Pid        int    `xml:"pid"`
+	SizeTotal  uint64 `xml:"sizeTotal"`
+	SizeFree   uint64 `xml:"sizeFree"`
+	Device     string `xml:"device"`
+	BlockSize  int    `xml:"blockSize"`
+	MntOptions string `xml:"mntOptions"`
+	FsName     string `xml:"fsName"`
+	// As of Gluster3.12 this shows filesystem type. Bug?
+	//InodeSize  uint64 `xml:"inodeSize"`
+	InodesTotal uint64 `xml:"inodesTotal"`
+	InodesFree  uint64 `xml:"inodesFree"`
+}
+
+// Ports XML type of "gluster volume status detail"
+type Ports struct {
+	TCP  int    `xml:"tcp"`
+	RDMA string `xml:"rdma"`
 }
 
 // VolumeStatusAllDetailXMLUnmarshall reads bytes.buffer and returns unmarshalled xml

--- a/structs/xmlStructs.go
+++ b/structs/xmlStructs.go
@@ -32,14 +32,23 @@ type Volumes struct {
 
 // Volume element of "gluster volume info" command
 type Volume struct {
-	XMLName    xml.Name `xml:"volume"`
-	Name       string   `xml:"name"`
-	ID         string   `xml:"id"`
-	Status     int      `xml:"status"`
-	StatusStr  string   `xml:"statusStr"`
-	BrickCount int      `xml:"brickCount"`
-	Bricks     []Brick  `xml:"bricks"`
-	DistCount  int      `xml:"distCount"`
+	XMLName         xml.Name `xml:"volume"`
+	Name            string   `xml:"name"`
+	ID              string   `xml:"id"`
+	Status          int      `xml:"status"`
+	StatusStr       string   `xml:"statusStr"`
+	BrickCount      int      `xml:"brickCount"`
+	Bricks          []Brick  `xml:"bricks"`
+	DistCount       int      `xml:"distCount"`
+	SnapshotCount   int      `xml:"snapshotCount"`
+	StripeCount     int      `xml:"stripeCount"`
+	ReplicaCount    int      `xml:"replicaCount"`
+	ArbiterCount    int      `xml:"arbiterCount"`
+	DisperseCount   int      `xml:"disperseCount"`
+	RedundancyCount int      `xml:"redundancyCount"`
+	Type            int      `xml:"type"`
+	TypeStr         string   `xml:"typeStr"`
+	Transport       int      `xml:"transport"`
 }
 
 // Brick element of "gluster volume info" command
@@ -108,6 +117,7 @@ type VolumeProfileXML struct {
 // VolProfile element of "gluster volume {volume} profile" command
 type VolProfile struct {
 	Volname    string         `xml:"volname"`
+	ProfileOp  int            `xml:"profileOp"`
 	BrickCount int            `xml:"brickCount"`
 	Brick      []BrickProfile `xml:"brick"`
 }
@@ -121,10 +131,11 @@ type BrickProfile struct {
 
 // CumulativeStats element of "gluster volume {volume} profile" command
 type CumulativeStats struct {
-	FopStats   FopStats `xml:"fopStats"`
-	Duration   int      `xml:"duration"`
-	TotalRead  int      `xml:"totalRead"`
-	TotalWrite int      `xml:"totalWrite"`
+	BlockStats BlockStats `xml:"blockStats"`
+	FopStats   FopStats   `xml:"fopStats"`
+	Duration   int        `xml:"duration"`
+	TotalRead  int        `xml:"totalRead"`
+	TotalWrite int        `xml:"totalWrite"`
 }
 
 // FopStats element of "gluster volume {volume} profile" command
@@ -141,9 +152,22 @@ type Fop struct {
 	MaxLatency float64 `xml:"maxLatency"`
 }
 
+// BlockStats element of "gluster volume {volume} profile" command
+type BlockStats struct {
+	Block []Block `xml:"block"`
+}
+
+// Block is struct for BlockStats
+type Block struct {
+	Size   int `xml:"size"`
+	Reads  int `xml:"reads"`
+	Writes int `xml:"writes"`
+}
+
 // HealInfoBrick is a struct of HealInfoBricks
 type HealInfoBrick struct {
 	XMLName         xml.Name `xml:"brick"`
+	HostUUID        string   `xml:"hostUuid,attr"`
 	Name            string   `xml:"name"`
 	Status          string   `xml:"status"`
 	NumberOfEntries string   `xml:"numberOfEntries"`


### PR DESCRIPTION
Hi:
   I am configuring a Docker Swarm cluster together with GlusterFS, when I am trying to add some monitoring tool based on [Grafana/Prometheus](https://github.com/stefanprodan/swarmprom) I found your exporter.
   It works OK in stand-alone mode but when I running at our servers I found some 500 errors, similar to #16 .
   In our cases is connected to Gluster Volumes with multiples mount points, for example:
`8 error(s) occurred:
* collected metric gluster_mount_successful label:<name:"mountpoint" value:"/var/lib/docker/plugins/3605e14efb9baa6e5a3f68e644cdaf7b175ee43cfc64e4aa097c0676af376d1d/propagated-mount/f2efb854877dfeda195ba193a6babcc355ca99fdcad163d7d017fe516f2968fe" > label:<name:"volume" value:"localhost:unifi/db" > gauge:<value:1 >  was collected before with the same name and label values
* collected metric gluster_volume_writeable label:<name:"mountpoint" value:"/var/lib/docker/plugins/3605e14efb9baa6e5a3f68e644cdaf7b175ee43cfc64e4aa097c0676af376d1d/propagated-mount/f2efb854877dfeda195ba193a6babcc355ca99fdcad163d7d017fe516f2968fe" > label:<name:"volume" value:"localhost:unifi/db" > gauge:<value:1 >  was collected before with the same name and label values
* collected metric gluster_mount_successful label:<name:"mountpoint" value:"/var/lib/docker/plugins/3605e14efb9baa6e5a3f68e644cdaf7b175ee43cfc64e4aa097c0676af376d1d/propagated-mount/cf17c635315406a6712258219b794d10c6ae552ae93a93b22d9f6e34cd1b9102" > label:<name:"volume" value:"localhost:unifi/data" > gauge:<value:1 >  was collected before with the same name and label values
* collected metric gluster_volume_writeable label:<name:"mountpoint" value:"/var/lib/docker/plugins/3605e14efb9baa6e5a3f68e644cdaf7b175ee43cfc64e4aa097c0676af376d1d/propagated-mount/cf17c635315406a6712258219b794d10c6ae552ae93a93b22d9f6e34cd1b9102" > label:<name:"volume" value:"localhost:unifi/data" > gauge:<value:1 >  was collected before with the same name and label values
* collected metric gluster_mount_successful label:<name:"mountpoint" value:"/var/lib/docker/plugins/3605e14efb9baa6e5a3f68e644cdaf7b175ee43cfc64e4aa097c0676af376d1d/propagated-mount/a6fa8065851be6a988798594e0c494aa48a0dbfa4326febaa5cdcf90ddb589f6" > label:<name:"volume" value:"localhost:unifi/db" > gauge:<value:1 >  was collected before with the same name and label values
* collected metric gluster_volume_writeable label:<name:"mountpoint" value:"/var/lib/docker/plugins/3605e14efb9baa6e5a3f68e644cdaf7b175ee43cfc64e4aa097c0676af376d1d/propagated-mount/a6fa8065851be6a988798594e0c494aa48a0dbfa4326febaa5cdcf90ddb589f6" > label:<name:"volume" value:"localhost:unifi/db" > gauge:<value:1 >  was collected before with the same name and label values
* collected metric gluster_mount_successful label:<name:"mountpoint" value:"/var/lib/docker/plugins/3605e14efb9baa6e5a3f68e644cdaf7b175ee43cfc64e4aa097c0676af376d1d/propagated-mount/bf196d84b6e1f4d37224e11e4e453c98e0130df6bd38fcd483818454647ae107" > label:<name:"volume" value:"localhost:unifi/data" > gauge:<value:1 >  was collected before with the same name and label values
* collected metric gluster_volume_writeable label:<name:"mountpoint" value:"/var/lib/docker/plugins/3605e14efb9baa6e5a3f68e644cdaf7b175ee43cfc64e4aa097c0676af376d1d/propagated-mount/bf196d84b6e1f4d37224e11e4e453c98e0130df6bd38fcd483818454647ae107" > label:<name:"volume" value:"localhost:unifi/data" > gauge:<value:1 >  was collected before with the same name and label values
` 
   they are related to [Docker volume Plugin](https://github.com/trajano/docker-volume-plugins) used by Swarm Services.
   Anyway this PR fix that problem ignoring mounts points starting with /var/lib/docker/plugins/, also have an update on the code to work with Gluster 7.x release.
   Best regards, Marcelo.
